### PR TITLE
Add Functionalities to Guardian and Orphan

### DIFF
--- a/src/modules/guardian/dto/create-guardian.dto.ts
+++ b/src/modules/guardian/dto/create-guardian.dto.ts
@@ -1,1 +1,58 @@
-export class CreateGuardianDto {}
+import {IsEmail, IsNotEmpty, IsOptional, IsString, ValidateIf,ValidateNested } from 'class-validator';
+  import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+  import { CreateProfileDto } from '../../users/dtos/profile/create-user-profile.dto';
+  import { Type } from 'class-transformer';
+  
+  export class CreateGuardianDto {
+    @ApiPropertyOptional({
+      description: 'Optional phone number of the user',
+      example: '07012345678',
+    })
+    @IsOptional()
+    @IsString()
+    phoneNumber: string;
+  
+    @ApiProperty({
+      description: "Password for the user's account",
+      example: 'P@ssw0rd',
+    })
+    @IsNotEmpty()
+    @IsString()
+    password: string;
+  
+    @ApiProperty({
+      description: "role for the user's account",
+      example: 'guardian',
+    })
+    @IsNotEmpty()
+    @IsString()
+    role: string;
+  
+    @ApiProperty({
+      description:
+        'Email address of the user, required if phone number is not provided',
+      example: 'ibrex@gmail.com',
+    })
+    @ValidateIf((o) => o.email !== undefined || o.phoneNumber === undefined)
+    @IsNotEmpty()
+    @IsEmail()
+    email: string;
+  
+  
+  
+    @ApiPropertyOptional({
+      description: 'Profile information of the user',
+      type: CreateProfileDto,
+      example: {
+        firstName: 'ibrahim',
+        middleName: ' ',
+        lastName: 'Muhammad',
+        dateOfBirth: '1990-01-01T00:00:00.000Z',
+      },
+    })
+    @ValidateNested()
+    @Type(() => CreateProfileDto)
+    @IsOptional()
+    profile?: CreateProfileDto;
+  }
+  

--- a/src/modules/guardian/guardian.controller.ts
+++ b/src/modules/guardian/guardian.controller.ts
@@ -1,8 +1,11 @@
-import { Controller, Get, Post, Body, Param, NotFoundException} from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, Param, NotFoundException} from '@nestjs/common';
 import { GuardianService } from './guardian.service';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
-import { CreateUserDto } from '../users/dtos/user/create-user.dto';
+import { CreateGuardianDto } from './dto/create-guardian.dto';
+import { UpdateGuardianDto } from './dto/update-guardian.dto';
 import { Public } from 'src/common/constants/routes.constant';
+import { User as UserDecorator } from 'src/common/decorators/param-decorator/User.decorator';
+import { User } from '@prisma/client';
 
 @ApiBearerAuth()
 @ApiTags("guardian")
@@ -12,18 +15,28 @@ export class GuardianController {
 
   @Public()
   @Post('')
-  createUser(@Body() createUserDto: CreateUserDto) {
-    return this.guardianService.createGuardian(createUserDto);
+  createUser(@Body() createGuardianDto: CreateGuardianDto) {
+    return this.guardianService.createGuardian(createGuardianDto);
   }
 
+  @Put(':id')
+  async updateGuardian(@UserDecorator('userId') userId: string, @Body() updateGuardianDto: UpdateGuardianDto): Promise<User> {
+    return this.guardianService.updateGuardian(userId, updateGuardianDto);
+  }
+  
   @Get()
   async getAllGuardian(){
     return this.guardianService.getAllGuardian();
   }
 
-  @Get(':id/has-orphans')
-  async checkGuardianOrphans(@Param('id') id: string) {
-    return await this.guardianService.hasOrphans(id);
+  @Get('has-orphans')
+  async checkGuardianOrphans(@UserDecorator('userId') userId: string) {
+    return await this.guardianService.hasOrphans(userId);
+  }
+
+  @Get('top-guardian')
+  async getGuardianSummary() {
+    return await this.guardianService.getTopGuardian();  
   }
 
 }

--- a/src/modules/orphan/controllers/orphan.controller.ts
+++ b/src/modules/orphan/controllers/orphan.controller.ts
@@ -51,4 +51,9 @@ export class OrphanController {
     return this.orphanService.deleteOrphan(orphanId, userId);
   }
 
+  @Get('orphans-stats')
+  async getAllOrphansStats() {
+    return this.orphanService.getAllOrphansStats();
+  }
+
 }

--- a/src/modules/orphan/controllers/request.controller.ts
+++ b/src/modules/orphan/controllers/request.controller.ts
@@ -18,7 +18,7 @@ import {
 import { RequestService } from '../request.service';
 import { User } from 'src/common/decorators/param-decorator/User.decorator';
 
-  
+@ApiBearerAuth()
 @ApiTags('Request')
 @Controller({ path: 'request', version: '1' })
 export class RequestController {


### PR DESCRIPTION
This PR adds the functionalities for getting orphan statistics, updating guardian information and returning the guardians with the highest number of orphans.

Major changes include:
- Implemented getTotalOrphans(), getNeeds() and getOrphanGenderCount() as private methods which:
   - getTotalOrphans() returns the count of all orphans who are not deleted
   - getNeeds() returns the count of all unique needs along with their count, amount needed and amount received
   -  getOrphanGenderCount() returns all the name and count of unique gender entries
- Implemented getAllOrphansStats() which was the public method that returned the data of the above private methods
- Updated the controller to handle the endpoint GET /orphans-stats that triggers this check.

- Implemented updateGuardian() which allows updating guardian information. Returns updated information (name, email, phone number, date of birth) and id of the user who made the update.
- Implemented getTopGuardian() to return the guardians (name, email and picture) with the highest orphans ordered in descending order
- Updated the controller to handle PUT /id to handle updates
- Updated the controller to handle GET /top-guardian to retrieve top guardians


Minor changes include:
- Updated the Guardian Controller to handle GET /has-orphans instead of GET /id/has-orphans
- Populated CreateGuardianDto
- Replaced CreateUserDto with CreateGuardianDto in controller and service