### PR TITLE
Implemented methods to get orphan stats for guardian and all deletion requests functionalities

### DIFF
--- a/src/modules/orphan/controllers/orphan.controller.ts
+++ b/src/modules/orphan/controllers/orphan.controller.ts
@@ -55,6 +55,16 @@ export class OrphanController {
     return this.orphanService.getAllOrphans();
   }
 
+  @Get('all-deletion-requests')
+  async getOrphansWithDeletionRequests() {
+    return this.orphanService.getOrphansWithDeletionRequests();
+  }
+  
+  @Get('orhpan-stats-for-guardian')
+  async getOrphanStatsForGuardian(@User('userId') userId: string) {
+    return this.orphanService.getOrphanStatsForGuardian(userId);
+  }
+
   @UseGuards(JwtAuthGuard)
   @Delete('deletion-request')
   async orphanDeletionRequest(@Body() dto: OrphanRemovalDto, @User('userId') userId: string): Promise<Orphan> {


### PR DESCRIPTION
This PR adds the functionality for returning all orphan deletion requests and orphan statics associated with a particular guardian.

Changes include:

Implemented getOrphansWithDeletionRequests function in the service layer, which returns all orphans whose Delete status is set to deletion request.

<img width="618" alt="Screenshot 2024-11-21 at 00 25 56" src="https://github.com/user-attachments/assets/46ec33ea-1dee-4bb6-a3f0-2fd15ceda53a">

Implemented the public method getOrphanStatsForGuardian which returns data from the following private methods:
  - getOrphanGenderCountForGuardian which returns all unique orphan genders for a guardian
  - getNeedsForGuardian which returns all unique needs and their count for a guardian
  - getTotalOrphansForGuardian which returns total orphans for a guardian 

<img width="559" alt="Screenshot 2024-11-21 at 00 26 56" src="https://github.com/user-attachments/assets/8a171e34-e11e-4704-8d8a-a5b989192515">

Updated the controller to handle the endpoint GET /all-deletion-requests and /orhpan-stats-for-guardian to handle the new methods.

<img width="618" alt="Screenshot 2024-11-21 at 00 24 55" src="https://github.com/user-attachments/assets/37adaf68-519a-4483-9369-4095c37447c5">
