### PR TITLE
Update Request Endpoint Changed and Delete draft endpoint created

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -281,9 +281,6 @@ model SupportingDocument {
   @@map("supporting_documents")
 }
 
-
-
-
 model Need {
   id                 String   @id @default(uuid())
   createdAt          DateTime @default(now())

--- a/src/modules/guardian/guardian.controller.ts
+++ b/src/modules/guardian/guardian.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Body, Param, Patch, Query, UseGuards} from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, Param, Patch, Query, UseGuards, Delete} from '@nestjs/common';
 import { GuardianService } from './guardian.service';
 import { ApiBearerAuth, ApiResponse, ApiTags,ApiOperation } from '@nestjs/swagger';
 import { CreateGuardianDto } from './dto/create-guardian.dto';
@@ -102,6 +102,12 @@ export class SponsorshipController {
   @ApiOperation({ summary: 'Retrieve a sponsorship request by ID' })
   async getById(@Param('id') id: string) {
     return this.guardianService.getSponsorshipRequestById(id);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete draft requests' })
+  async deleteDraftRequest(@Param('id') id:string){
+    return this.guardianService.deleteDraftRequest(id);
   }
 }
 


### PR DESCRIPTION
The update endpoint now ensures that only draft sponsorship requests can be modified, preventing unintended changes to active requests. A database transaction was introduced to make sure that all updates succeed or fail together. Supporting document updates were improved by deleting existing documents before inserting new ones, avoiding duplication and keeping the data clean. 
<img width="785" alt="Screenshot 2025-02-13 at 20 00 53" src="https://github.com/user-attachments/assets/2b935ff4-7572-496f-a754-90b4ea08e79d" />

A delete endpoint was created to remove all related records before deleting the sponsorship request. A check was added to verify that the request is in draft status, so only drafts can be deleted. The deletion process also includes removing related supporting documents and action logs before deleting the request itself. 
<img width="727" alt="Screenshot 2025-02-13 at 20 01 24" src="https://github.com/user-attachments/assets/5676722b-6f7d-4add-8376-88c53493428a" />







